### PR TITLE
Handle user setting being None.

### DIFF
--- a/sentry_irc/plugin.py
+++ b/sentry_irc/plugin.py
@@ -76,7 +76,7 @@ class IRCMessage(Plugin):
         nick = self.get_option('nick', project)
         rooms = self.get_option('room', project)
         without_join = self.get_option('without_join', project)
-        users = self.get_option('user', project)
+        users = self.get_option('user', project) or ''
         rooms = [x.startswith('#') and x or '#%s' % x
                  for x in [x.strip() for x in rooms.split(',')]]
         users = [x.strip() for x in users.split(',')]


### PR DESCRIPTION
The user setting was added in #3.

Anyone who upgraded from a previous version will have user set to None.

Converting that None to an empty string will keep the later string operations from throwing exceptions.
