### PR TITLE
Utilize specified IRC password.

### DIFF
--- a/sentry_irc/plugin.py
+++ b/sentry_irc/plugin.py
@@ -89,6 +89,8 @@ class IRCMessage(Plugin):
             ircsock = wrap_socket(irc)
         else:
             ircsock = irc
+        if password:
+            ircsock.send("PASS %s\n" % password)
         ircsock.send("USER %s %s %s :Sentry IRC bot\n" % ((nick,) * 3))
         ircsock.send("NICK %s\n" % nick)
         while 1:


### PR DESCRIPTION
Currently, although the IRC password may be specified in sentry options, it is not utilized while connecting to the IRC server.  This change adds such functionality.
