### PR TITLE
Port is an INT

### DIFF
--- a/sentry_irc/plugin.py
+++ b/sentry_irc/plugin.py
@@ -102,7 +102,9 @@ class IRCMessage(NotificationPlugin):
 
     def send_payload(self, project, message):
         server = self.get_option('server', project)
-        port = self.get_option('port', project)
+        port = int(self.get_option('port', project))
+        if port == 0:
+            return
         nick = self.get_option('nick', project)
         rooms = self.get_option('room', project) or ''
         without_join = self.get_option('without_join', project)


### PR DESCRIPTION
In testing this against the current versions of Sentry, 8.10.0, I hit an error with the port being a `string` instead of an `int`.  This resolves that, and forces a return if the port value is `0` after being cast to `int`.